### PR TITLE
Fix bug with get_user_index

### DIFF
--- a/CholitoProject/CholitoProject/userManager.py
+++ b/CholitoProject/CholitoProject/userManager.py
@@ -1,12 +1,21 @@
+from django.core.exceptions import ObjectDoesNotExist
+
 from naturalUser.models import NaturalUser
 from municipality.models import MunicipalityUser
 
 
+def get_user_or_none(model, user):
+    try:
+        the_user = model.objects.get(user=user)
+    except ObjectDoesNotExist:
+        the_user = None
+    return the_user
+
 def get_user_index(user):
-    original_user = NaturalUser.objects.get(user=user)
+    original_user = get_user_or_none(NaturalUser, user)
     if original_user is not None:
         return original_user
-    original_user = MunicipalityUser.objects.get(user=user)
+    original_user = get_user_or_none(MunicipalityUser, user)
     if original_user is not None:
         return original_user
     else:


### PR DESCRIPTION
NaturalUser.objects.get(user=user) devuelve un objeto NaturalUser si existe user, pero si no existe tira naturalUser.models.DoesNotExist en vez de None. Ahora devuelve correctamente None.